### PR TITLE
Filter resources without list

### DIFF
--- a/src/TreeMenu.js
+++ b/src/TreeMenu.js
@@ -78,6 +78,7 @@ const Menu = ({
      */
     resRenderGroup.push(
         resources.filter(r => r.options && !r.options.hasOwnProperty('menuParent') && !r.options.hasOwnProperty('isMenuParent'))
+            .filter(r => r.hasList)
             .map(independentResource => (
                 <MenuItemLink
                     key={independentResource.name}


### PR DESCRIPTION
Currently resources without list are listed on the menu, filtering by resource.hasList fixes that, as done on react-admin:

https://github.com/marmelab/react-admin/blob/7f6426e07916d32b5c9015c82540ac439b4a9e28/packages/ra-ui-materialui/src/layout/Menu.tsx#L77