### PR TITLE
multiple improvements

### DIFF
--- a/src/CustomMenuItem.js
+++ b/src/CustomMenuItem.js
@@ -36,6 +36,7 @@ const CustomMenuItem = ({ handleToggle, sidebarIsOpen, isOpen, name, icon, child
 
     const header = (
         <MenuItem 
+            key={name}
             dense={dense} 
             button 
             onClick={handleToggle}

--- a/src/CustomMenuItem.js
+++ b/src/CustomMenuItem.js
@@ -8,7 +8,6 @@ import Typography from '@material-ui/core/Typography';
 import Collapse from '@material-ui/core/Collapse';
 import Tooltip from '@material-ui/core/Tooltip';
 import { makeStyles } from '@material-ui/core/styles';
-// import Divider from '@material-ui/core/Divider';
 
 
 const useStyles = makeStyles(theme => ({
@@ -61,7 +60,6 @@ const CustomMenuItem = ({ handleToggle, sidebarIsOpen, isOpen, name, icon, child
                 >
                     {children}
                 </List>
-                {/* <Divider/> */}
             </Collapse>
         </Fragment>
     );

--- a/src/CustomMenuItem.js
+++ b/src/CustomMenuItem.js
@@ -53,7 +53,7 @@ const CustomMenuItem = ({ handleToggle, sidebarIsOpen, isOpen, name, icon, child
                     'menuItemName'
                 )}
             >
-                {name}
+                {translate(name)}
             </Typography>
         </MenuItem>
     );

--- a/src/CustomMenuItem.js
+++ b/src/CustomMenuItem.js
@@ -1,5 +1,5 @@
 import React, { Fragment } from 'react';
-import { translate } from 'react-admin';
+import { useTranslate } from 'react-admin';
 import ExpandMore from '@material-ui/icons/ExpandMore';
 import List from '@material-ui/core/List';
 import MenuItem from '@material-ui/core/MenuItem';
@@ -32,6 +32,7 @@ const useStyles = makeStyles(
 
 const CustomMenuItem = ({ handleToggle, sidebarIsOpen, isOpen, name, icon, children, dense, }) => {
     const classes = useStyles();
+    const translate = useTranslate();
 
     const header = (
         <MenuItem 

--- a/src/CustomMenuItem.js
+++ b/src/CustomMenuItem.js
@@ -8,30 +8,51 @@ import Typography from '@material-ui/core/Typography';
 import Collapse from '@material-ui/core/Collapse';
 import Tooltip from '@material-ui/core/Tooltip';
 import { makeStyles } from '@material-ui/core/styles';
+import classnames from 'classnames';
 
-
-const useStyles = makeStyles(theme => ({
-    icon: { minWidth: theme.spacing(5) },
-    sidebarIsOpen: {
-        paddingLeft: 25,
-        transition: 'padding-left 195ms cubic-bezier(0.4, 0, 0.6, 1) 0ms',
-    },
-    sidebarIsClosed: {
-        paddingLeft: 0,
-        transition: 'padding-left 195ms cubic-bezier(0.4, 0, 0.6, 1) 0ms',
-    },
-}));
-
+const useStyles = makeStyles(
+    theme => ({
+        icon: { minWidth: theme.spacing(5) },
+        sidebarIsOpen: {
+            paddingLeft: 25,
+            transition: 'padding-left 195ms cubic-bezier(0.4, 0, 0.6, 1) 0ms',
+        },
+        sidebarIsClosed: {
+            paddingLeft: 0,
+            transition: 'padding-left 195ms cubic-bezier(0.4, 0, 0.6, 1) 0ms',
+        },
+        menuItem: {},
+        menuItemName: {
+            color: theme.palette.text.secondary
+        },
+        openMenuItem: {}
+    }),
+    { name: 'RaTreeCustomMenuItem' }
+);
 
 const CustomMenuItem = ({ handleToggle, sidebarIsOpen, isOpen, name, icon, children, dense, }) => {
     const classes = useStyles();
 
     const header = (
-        <MenuItem dense={dense} button onClick={handleToggle}>
+        <MenuItem 
+            dense={dense} 
+            button 
+            onClick={handleToggle}
+            className={classnames(
+                classes.menuItem,
+                {[classes.openMenuItem]: isOpen}
+            )}
+        >
             <ListItemIcon className={classes.icon}>
                 {isOpen ? <ExpandMore /> : icon}
             </ListItemIcon>
-            <Typography variant="inherit" color="textSecondary">
+            <Typography
+                variant="inherit" 
+                className={classnames(
+                    classes.menuItemName,
+                    'menuItemName'
+                )}
+            >
                 {name}
             </Typography>
         </MenuItem>

--- a/src/TreeMenu.js
+++ b/src/TreeMenu.js
@@ -2,10 +2,15 @@ import React, { useState } from 'react';
 import LabelIcon from '@material-ui/icons/Label';
 import { useMediaQuery, Theme } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
-import { MenuItemLink, getResources, translate, DashboardMenuItem } from 'react-admin';
+import { 
+    MenuItemLink,
+    getResources,
+    useTranslate, 
+    translate, 
+    DashboardMenuItem
+} from 'react-admin';
 import PropTypes from 'prop-types';
-import { connect, useSelector } from 'react-redux';
-import { compose } from 'recompose';
+import { useSelector, shallowEqual } from 'react-redux';
 import { withStyles } from '@material-ui/core/styles';
 import classnames from 'classnames';
 import DefaultIcon from '@material-ui/icons/ViewList';
@@ -35,20 +40,20 @@ const Menu = (props) => {
         dense,
         hasDashboard,
         onMenuClick,
-        open,
-        pathname,
-        resources,
-        translate,
         logout,
         ...rest
     } = props;
     const classes = useStyles(props);
+    const translate = useTranslate();
+    const open = useSelector((state) => state.admin.ui.sidebarOpen);
+    const pathname = useSelector((state) => state.router.location.pathname);
+    const resources = useSelector(getResources, shallowEqual);
 
     const handleToggle = (parent) => {
         setState(state => ({ [parent]: !state[parent] }));
     };
 
-    const isXSmall = useMediaQuery((theme: Theme) =>
+    const isXSmall = useMediaQuery((theme) =>
         theme.breakpoints.down('xs')
     );
 
@@ -155,9 +160,6 @@ const Menu = (props) => {
         }
     });
 
-    // Used to force redraw on navigation
-    useSelector(() => state.router.location.pathname);
-
     return (
         <div>
             <div
@@ -185,40 +187,11 @@ Menu.propTypes = {
     hasDashboard: PropTypes.bool,
     logout: PropTypes.element,
     onMenuClick: PropTypes.func,
-    open: PropTypes.bool,
-    pathname: PropTypes.string,
-    resources: PropTypes.array.isRequired,
-    translate: PropTypes.func.isRequired
 };
 
 Menu.defaultProps = {
     onMenuClick: () => null
 };
 
-const mapStateToProps = state => ({
-    open: state.admin.ui.sidebarOpen,
-    resources: getResources(state),
-    pathname: state.router.location.pathname
-});
 
-const enhance = compose(
-    translate,
-    connect(
-        mapStateToProps,
-        {}, // Avoid connect passing dispatch in props,
-        null,
-        {
-            areStatePropsEqual: (prev, next) =>
-                prev.resources.every(
-                    (value, index) => value === next.resources[index] // shallow compare resources
-                ) &&
-                // eslint-disable-next-line
-                prev.pathname == next.pathname &&
-                // eslint-disable-next-line
-                prev.open == next.open
-        }
-    ),
-    withStyles(null)
-);
-
-export default enhance(Menu);
+export default Menu;

--- a/src/TreeMenu.js
+++ b/src/TreeMenu.js
@@ -160,8 +160,17 @@ const Menu = (props) => {
 
     return (
         <div>
-            <div style={{marginTop: '10px'}} className={classnames(classes.main, className)} {...rest}>
-                {hasDashboard && <DashboardMenuItem onClick={onMenuClick} />}
+            <div
+                className={classnames(classes.main, className)} 
+                {...rest}
+            >
+                {hasDashboard && (
+                    <DashboardMenuItem
+                        onClick={onMenuClick}
+                        dense={dense}
+                        sidebarIsOpen={open}
+                    />
+                )}
                 {resRenderGroup}
                 {isXSmall && logout}
             </div>

--- a/src/TreeMenu.js
+++ b/src/TreeMenu.js
@@ -48,6 +48,10 @@ const Menu = (props) => {
         setState(state => ({ [parent]: !state[parent] }));
     };
 
+    const isXSmall = useMediaQuery((theme: Theme) =>
+        theme.breakpoints.down('xs')
+    );
+
     const isParent = (resource) => {
         return (
             resource.options && 
@@ -159,6 +163,7 @@ const Menu = (props) => {
             <div style={{marginTop: '10px'}} className={classnames(classes.main, className)} {...rest}>
                 {hasDashboard && <DashboardMenuItem onClick={onMenuClick} />}
                 {resRenderGroup}
+                {isXSmall && logout}
             </div>
         </div>
     );

--- a/src/TreeMenu.js
+++ b/src/TreeMenu.js
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
 import LabelIcon from '@material-ui/icons/Label';
+import { useMediaQuery, Theme } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
 import { MenuItemLink, getResources, translate, DashboardMenuItem } from 'react-admin';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -9,88 +11,145 @@ import classnames from 'classnames';
 import DefaultIcon from '@material-ui/icons/ViewList';
 import CustomMenuItem from './CustomMenuItem';
 
-const Menu = ({
-    classes,
-    className,
-    dense,
-    hasDashboard,
-    onMenuClick,
-    open,
-    pathname,
-    resources,
-    translate,
-    logout,
-    ...rest
-}) => {
+const useStyles = makeStyles(
+    theme => ({
+        main: {
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'flex-start',
+            marginTop: '0.5em',
+            [theme.breakpoints.only('xs')]: {
+                marginTop: 0,
+            },
+            [theme.breakpoints.up('md')]: {
+                marginTop: '1.5em',
+            },
+        },
+    }),
+    { name: 'RaTreeMenu' }
+);
+
+const Menu = (props) => {
+    const {
+        className,
+        dense,
+        hasDashboard,
+        onMenuClick,
+        open,
+        pathname,
+        resources,
+        translate,
+        logout,
+        ...rest
+    } = props;
+    const classes = useStyles(props);
 
     const handleToggle = (parent) => {
         setState(state => ({ [parent]: !state[parent] }));
     };
 
     const isParent = (resource) => {
-        return resource.options && resource.options.hasOwnProperty('isMenuParent') && resource.options.isMenuParent;
-    }
+        return (
+            resource.options && 
+            resource.options.hasOwnProperty('isMenuParent') && 
+            resource.options.isMenuParent
+        );
+    };
+
+    const isOrphan = (resource) =>{
+        return (
+            resource.options && 
+            !resource.options.hasOwnProperty('menuParent') && 
+            !resource.options.hasOwnProperty('isMenuParent')
+        )
+    };
+
+    /**
+     * Mapping independent (without a parent) entries
+     */
+    const mapIndependent = (independentResource) =>
+        <MenuItemLink
+            key={independentResource.name}
+            to={`/${independentResource.name}`}
+            primaryText={independentResource.options.label}
+            leftIcon={
+                independentResource.icon 
+                    ? <independentResource.icon/> 
+                    : <DefaultIcon/>
+            }
+            onClick={onMenuClick}
+            dense={dense}
+            sidebarIsOpen={open}
+        />;
 
     const initialExpansionState = {};
+    let parentActiveResName = null;
+
+    // initialize all parents to unexpanded first, and also find active resource
     resources.forEach(res => {
         if (isParent(res)) {
             initialExpansionState[res.name] = false;
+        } else if (
+            pathname.startsWith(`/${res.name}`) && 
+            res.options.hasOwnProperty('menuParent')
+        ) {
+            parentActiveResName = res.options.menuParent;
         }
     });
+
     const [state, setState] = useState(initialExpansionState);
+
+    /**
+     * Mapping a "parent" entry and then all its children to the "tree" layout
+     */
+    const mapParentStack = (parentResource) =>
+        <CustomMenuItem
+            handleToggle={() => handleToggle(parentResource.name)}
+            isOpen={state[parentResource.name] || parentActiveResName === parentResource.name}
+            sidebarIsOpen={open}
+            name={parentResource.options.label}
+            icon={parentResource.icon ? <parentResource.icon/> : <LabelIcon/>}
+            dense={dense}
+        >
+            {
+                // eslint-disable-next-line
+                resources
+                    .filter((resource) => (
+                        resource.options &&
+                        resource.options.hasOwnProperty('menuParent') && 
+                        resource.options.menuParent == parentResource.name
+                    ))
+                    .map((childResource) => (
+                        <MenuItemLink
+                            key={childResource.name}
+                            to={`/${childResource.name}`}
+                            primaryText={childResource.options.label}
+                            leftIcon={
+                                childResource.icon 
+                                    ? <childResource.icon/> 
+                                    : <DefaultIcon/>
+                            }
+                            onClick={onMenuClick}
+                            dense={dense}
+                            sidebarIsOpen={open}
+                        />
+                    ))
+            }
+        </CustomMenuItem>;
+
     const resRenderGroup = [];
+
     /**
-     * Pushing the menu tree for rendering
+     * Pushing the menu tree for rendering in the order we find them declared
      */
-    resRenderGroup.push(
-        resources.filter(r => isParent(r))
-            .map(parentResource => (
-                <CustomMenuItem
-                    handleToggle={() => handleToggle(parentResource.name)}
-                    isOpen={state[parentResource.name]}
-                    sidebarIsOpen={open}
-                    name={parentResource.options.label}
-                    icon={parentResource.icon ? <parentResource.icon /> : <LabelIcon />}
-                    dense={dense}
-                >
-                    {
-                        // eslint-disable-next-line
-                        resources.filter(r => r.options && r.options.hasOwnProperty('menuParent') && r.options.menuParent == parentResource.name)
-                            .map(childResource => (
-                                <MenuItemLink
-                                    key={childResource.name}
-                                    to={`/${childResource.name}`}
-                                    primaryText={childResource.options.label}
-                                    leftIcon={
-                                        childResource.icon ? <childResource.icon /> : <DefaultIcon />
-                                    }
-                                    onClick={onMenuClick}
-                                    dense={dense}
-                                />
-                            ))
-                    }
-                </CustomMenuItem>
-            ))
-    );
-    /**
-     * Pushing the orphan resources for rendering
-     * below other menu items
-     */
-    resRenderGroup.push(
-        resources.filter(r => r.options && !r.options.hasOwnProperty('menuParent') && !r.options.hasOwnProperty('isMenuParent'))
-            .map(independentResource => (
-                <MenuItemLink
-                    key={independentResource.name}
-                    to={`/${independentResource.name}`}
-                    primaryText={independentResource.options.label}
-                    leftIcon={
-                        independentResource.icon ? <independentResource.icon /> : <DefaultIcon />
-                    }
-                    onClick={onMenuClick}
-                    dense={dense}
-                />
-            ))
-    );
+    resources.forEach(r => {
+        if(isParent(r)){
+            resRenderGroup.push(mapParentStack(r))
+        }
+        if(isOrphan(r)) {
+            resRenderGroup.push(mapIndependent(r))
+        }
+    });
     return (
         <div>
             <div style={{marginTop: '10px'}} className={classnames(classes.main, className)} {...rest}>

--- a/src/TreeMenu.js
+++ b/src/TreeMenu.js
@@ -6,7 +6,6 @@ import {
     MenuItemLink,
     getResources,
     useTranslate, 
-    translate, 
     DashboardMenuItem
 } from 'react-admin';
 import PropTypes from 'prop-types';
@@ -132,7 +131,7 @@ const Menu = (props) => {
                         <MenuItemLink
                             key={childResource.name}
                             to={`/${childResource.name}`}
-                            primaryText={childResource.options.label}
+                            primaryText={translate(childResource.options.label)}
                             leftIcon={
                                 childResource.icon 
                                     ? <childResource.icon/> 

--- a/src/TreeMenu.js
+++ b/src/TreeMenu.js
@@ -4,7 +4,7 @@ import { useMediaQuery, Theme } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import { MenuItemLink, getResources, translate, DashboardMenuItem } from 'react-admin';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { connect, useSelector } from 'react-redux';
 import { compose } from 'recompose';
 import { withStyles } from '@material-ui/core/styles';
 import classnames from 'classnames';
@@ -150,6 +150,10 @@ const Menu = (props) => {
             resRenderGroup.push(mapIndependent(r))
         }
     });
+
+    // Used to force redraw on navigation
+    useSelector(() => state.router.location.pathname);
+
     return (
         <div>
             <div style={{marginTop: '10px'}} className={classnames(classes.main, className)} {...rest}>

--- a/src/TreeMenu.js
+++ b/src/TreeMenu.js
@@ -112,6 +112,7 @@ const Menu = (props) => {
      */
     const mapParentStack = (parentResource) =>
         <CustomMenuItem
+            key={parentResource.name}
             handleToggle={() => handleToggle(parentResource.name)}
             isOpen={state[parentResource.name] || parentActiveResName === parentResource.name}
             sidebarIsOpen={open}
@@ -127,7 +128,8 @@ const Menu = (props) => {
                         resource.options.hasOwnProperty('menuParent') && 
                         resource.options.menuParent == parentResource.name
                     ))
-                    .map((childResource) => (
+                    .map((childResource) => {
+                        return (
                         <MenuItemLink
                             key={childResource.name}
                             to={`/${childResource.name}`}
@@ -141,7 +143,7 @@ const Menu = (props) => {
                             dense={dense}
                             sidebarIsOpen={open}
                         />
-                    ))
+                    )})
             }
         </CustomMenuItem>;
 


### PR DESCRIPTION
This pull includes several improvements:
- I've merged https://github.com/BigBasket/ra-treemenu/pull/13 pull request to support orphan resources (thanks for that @Mikayl, nice contribution!)
- Mouseover shows only tooltip when sidebar is collapsed (this is done by setting the sidebarIsOpen property, as in default ReactAdmin Menu, see https://github.com/marmelab/react-admin/blob/master/packages/ra-ui-materialui/src/layout/Menu.tsx#L91)
- Ensures that on first rendering, the parent menu item of the active menu item is open.
- shows logout only when isXSmall (as in react-admin Menu, see https://github.com/marmelab/react-admin/blob/master/packages/ra-ui-materialui/src/layout/Menu.tsx#L94)
- use theming for the TreeMenu component, and adds a bunch of theme classes to allow for theme overriding (which I do use in my code).
- Removes the commented lines related to the divider. (If the divider is useful, it could be added later as an optional property in CustomMenuItem).
- Based on current react-admin practices, I've transformed the code to be more functional by removing code making it a HOC.