### PR TITLE
Add custom menu items

### DIFF
--- a/src/TreeMenu.js
+++ b/src/TreeMenu.js
@@ -257,13 +257,15 @@ Menu.propTypes = {
     hasDashboard: PropTypes.bool,
     logout: PropTypes.element,
     onMenuClick: PropTypes.func,
-    dashboardlabel:PropTypes.string,
-    resources:PropTypes.array,
+    dashboardlabel: PropTypes.string,
+    resources: PropTypes.array,
+    customMenuItems: PropTypes.array,
 };
 
 Menu.defaultProps = {
     onMenuClick: () => null,
-    dashboardlabel: 'Dashboard'
+    dashboardlabel: 'Dashboard',
+    customMenuItems: []
 };
 
 

--- a/src/TreeMenu.js
+++ b/src/TreeMenu.js
@@ -51,6 +51,7 @@ const Menu = (props) => {
         logout,
         dashboardlabel,
         resources,
+        customMenuItems,  // List of MenuItemLink components
         ...rest
     } = props;
 
@@ -73,11 +74,11 @@ const Menu = (props) => {
         /**
          * This function is not directly used anywhere
          * but is required to fix the following error:
-         * 
+         *
          * Error: Rendered fewer hooks than expected.
          * This may be caused by an accidental early
          * return statement.
-         * 
+         *
          * thrown by RA at the time of rendering.
          */
         theme.breakpoints.down('xs')
@@ -99,7 +100,7 @@ const Menu = (props) => {
          * i.e. has no parents defined. Needed as
          * these resources are supposed to be rendered
          * as is
-         *  
+         *
          */
         resource.options &&
         !resource.options.hasOwnProperty('menuParent') &&
@@ -113,7 +114,7 @@ const Menu = (props) => {
          */
         resource.options &&
         resource.options.hasOwnProperty('menuParent') &&
-        resource.options.menuParent == parentResource.name
+        resource.options.menuParent === parentResource.name
     );
     const geResourceName = (slug) => {
         if (!slug) return;
@@ -221,6 +222,10 @@ const Menu = (props) => {
         if (isParent(r)) resRenderGroup.push(mapParentStack(r));
         if (isOrphan(r)) resRenderGroup.push(mapIndependent(r));
     });
+
+    if (customMenuItems) {
+        customMenuItems.forEach(menuItem => resRenderGroup.push(menuItem));
+    }
 
     return (
         <div>

--- a/src/TreeMenu.js
+++ b/src/TreeMenu.js
@@ -50,7 +50,7 @@ const Menu = (props) => {
         onMenuClick,
         logout,
         dashboardlabel,
-        resources,
+        resources: origResources,
         customMenuItems,  // List of MenuItemLink components
         ...rest
     } = props;
@@ -59,7 +59,7 @@ const Menu = (props) => {
     const translate = useTranslate();
     const open = useSelector((state) => state.admin.ui.sidebarOpen);
     const pathname = useSelector((state) => state.router.location.pathname);
-    const resources = resources || useSelector(getResources, shallowEqual);
+    const resources = origResources || useSelector(getResources, shallowEqual);
     const hasList = (resource) => (resource.hasList);
 
     const handleToggle = (parent) => {


### PR DESCRIPTION
Quick way to add custom menu items without Resource.

Usage:

```js
import * as UI from 'ra-ui-materialui';
import TreeMenu from '@bb-tech/ra-treemenu';
import Settings from '@material-ui/icons/Settings';

const CustomMenuItems = [
  <UI.MenuItemLink
    to="/settings"
    primaryText="Settings"
    leftIcon={<Settings />}
  />,
];

const CustomLayout = (props) => {
  TreeMenu.defaultProps.customMenuItems = CustomMenuItems;
  return <UI.Layout {...props} menu={TreeMenu} />;
};

const App = (props) => (
  <Admin
    layout={(props) => <CustomLayout {...props} />}
    {...props}
  >
    {props.children}
  </Admin>
);
```

---

Better way is to support custom menu items inside menu but I didn't investigate this option because
- there is RA v4 where CustomRoutes component exists
- I don't know how to update the code of the lib for this